### PR TITLE
Update build-depends to support ghc-9

### DIFF
--- a/type-errors-pretty.cabal
+++ b/type-errors-pretty.cabal
@@ -29,7 +29,7 @@ source-repository head
   location:            https://github.com/kowainik/type-errors-pretty.git
 
 common common-options
-  build-depends:       base >= 4.10.1.0 && < 4.15
+  build-depends:       base >= 4.10.1.0 && < 4.16
 
   ghc-options:         -Wall
                        -Wcompat


### PR DESCRIPTION
We can compile this package with ghc-9 by updating the upper limit of base-package.